### PR TITLE
Added function to generate which users have to be invited after the sync button is pressed

### DIFF
--- a/website/projects/awssync.py
+++ b/website/projects/awssync.py
@@ -99,3 +99,12 @@ class AWSSync:
             self.logger.error("Something went wrong creating an AWS organization.")
             self.logger.debug(f"{error}")
             self.logger.debug(f"{error.response}")
+
+    def generate_aws_sync_list(self, giphouse_data, aws_data):
+        """
+        Generate the list of users that are registered on the GiPhouse website, but are not yet invited for AWS.
+
+        This includes their ID and email address, to be able to put users in the correct AWS orginization later.
+        """
+        sync_list = [x for x in giphouse_data if x not in aws_data]
+        return sync_list

--- a/website/projects/tests/test_awssync.py
+++ b/website/projects/tests/test_awssync.py
@@ -128,3 +128,34 @@ class AWSSyncTest(TestCase):
         org.create_aws_organization()
         self.assertTrue(org.fail)
         self.assertIsNone(org.org_info)
+
+class AWSSyncList(TestCase):
+    """Test AWSSyncList class."""
+
+    def setUp(self):
+        self.sync = awssync.AWSSync()
+
+    def test_AWS_sync_list_both_empty(self):
+        gip_list = []
+        aws_list = []
+        self.assertEquals(self.sync.generate_aws_sync_list(gip_list, aws_list), [])
+
+    def test_AWS_sync_list_empty_AWS(self):
+        gip_list = [("test1@test.test", 37), ("test2@test.test", 37), ("test3@test.test", 37)]
+        aws_list = []
+        self.assertEquals(self.sync.generate_aws_sync_list(gip_list, aws_list), gip_list)
+
+    def test_AWS_sync_list_empty_GiP(self):
+        gip_list = []
+        aws_list = [("test1@test.test", 37), ("test2@test.test", 37)]
+        self.assertEquals(self.sync.generate_aws_sync_list(gip_list, aws_list), [])
+
+    def test_AWS_sync_list_diff_email(self):
+        gip_list = [("test1@test.test", 37), ("test2@test.test", 37), ("test3@test.test", 37)]
+        aws_list = [("test1@test.test", 37), ("test2@test.test", 37)]
+        self.assertEquals(self.sync.generate_aws_sync_list(gip_list, aws_list), [("test3@test.test", 37)])
+
+    def test_AWS_sync_list_diff_id(self):
+        gip_list = [("test1@test.test", 37), ("test1@test.test", 38), ("test1@test.test", 39)]
+        aws_list = [("test1@test.test", 37), ("test1@test.test", 38)]
+        self.assertEquals(self.sync.generate_aws_sync_list(gip_list, aws_list), [("test1@test.test", 39)])

--- a/website/projects/tests/test_awssync.py
+++ b/website/projects/tests/test_awssync.py
@@ -130,11 +130,16 @@ class AWSSyncTest(TestCase):
         self.assertIsNone(org.org_info)
 
 
-class AWSSyncList(TestCase):
+class AWSSyncListTest(TestCase):
     """Test AWSSyncList class."""
 
     def setUp(self):
         self.sync = awssync.AWSSync()
+        self.syncData = awssync.SyncData
+
+        self.test1 = self.syncData("test1@test1.test1", "test1", "test1")
+        self.test2 = self.syncData("test2@test2.test2", "test2", "test2")
+        self.test3 = self.syncData("test3@test3.test3", "test3", "test3")
 
     def test_AWS_sync_list_both_empty(self):
         gip_list = []
@@ -142,21 +147,16 @@ class AWSSyncList(TestCase):
         self.assertEquals(self.sync.generate_aws_sync_list(gip_list, aws_list), [])
 
     def test_AWS_sync_list_empty_AWS(self):
-        gip_list = [("test1@test.test", 37), ("test2@test.test", 37), ("test3@test.test", 37)]
+        gip_list = [self.test1, self.test2]
         aws_list = []
         self.assertEquals(self.sync.generate_aws_sync_list(gip_list, aws_list), gip_list)
 
     def test_AWS_sync_list_empty_GiP(self):
         gip_list = []
-        aws_list = [("test1@test.test", 37), ("test2@test.test", 37)]
+        aws_list = [self.test1, self.test2]
         self.assertEquals(self.sync.generate_aws_sync_list(gip_list, aws_list), [])
 
-    def test_AWS_sync_list_diff_email(self):
-        gip_list = [("test1@test.test", 37), ("test2@test.test", 37), ("test3@test.test", 37)]
-        aws_list = [("test1@test.test", 37), ("test2@test.test", 37)]
-        self.assertEquals(self.sync.generate_aws_sync_list(gip_list, aws_list), [("test3@test.test", 37)])
-
-    def test_AWS_sync_list_diff_id(self):
-        gip_list = [("test1@test.test", 37), ("test1@test.test", 38), ("test1@test.test", 39)]
-        aws_list = [("test1@test.test", 37), ("test1@test.test", 38)]
-        self.assertEquals(self.sync.generate_aws_sync_list(gip_list, aws_list), [("test1@test.test", 39)])
+    def test_AWS_sync_list_both_full(self):
+        gip_list = [self.test1, self.test2]
+        aws_list = [self.test2, self.test3]
+        self.assertEquals(self.sync.generate_aws_sync_list(gip_list, aws_list), [self.test1])

--- a/website/projects/tests/test_awssync.py
+++ b/website/projects/tests/test_awssync.py
@@ -129,6 +129,7 @@ class AWSSyncTest(TestCase):
         self.assertTrue(org.fail)
         self.assertIsNone(org.org_info)
 
+
 class AWSSyncList(TestCase):
     """Test AWSSyncList class."""
 


### PR DESCRIPTION
<!-- Specify the issue this pull request closes, if any. -->
Closes #10

### One-sentence description
Added function that user GiPhouse registrations and AWS accounts that are already invited to extract which users to invite for AWS when the sync button is pressed


### Description
See above
