### PR TITLE
refactored the necessary checks to other files, as well as their tests

### DIFF
--- a/website/projects/awssync_checks.py
+++ b/website/projects/awssync_checks.py
@@ -1,41 +1,32 @@
 from __future__ import annotations
 
-import logging
-
 from projects.awssync_structs import AWSTree
 
 
 class Checks:
-    """Class for pipline checks."""
-
-    def __init__(self) -> None:
-        """Initialize Checks class."""
-        self.logger = logging.getLogger("django.aws")
-        self.logger.setLevel(logging.DEBUG)
+    """Class for pipeline checks."""
 
     def check_members_in_correct_iteration(self, AWSdata: AWSTree) -> None:
         """Check if the data from the member tag matches the semester OU it is in."""
-        incorrect_emails = []
-        for iteration in AWSdata.iterations:
-            for member in iteration.members:
-                if member.project_semester != iteration.name:
-                    incorrect_emails.append(member.project_email)
+        emails_inconsistent_accounts = [
+            member.project_email
+            for iteration in AWSdata.iterations
+            for member in iteration.members
+            if member.project_semester != iteration.name
+        ]
 
-        if incorrect_emails != []:
-            self.logger.error("There are members in a course iteration OU with an inconsistent course iteration tag.")
-            self.logger.debug(f"{incorrect_emails}")
-            raise Exception("There are members in a course iteration OU with an inconsistent course iteration tag.")
+        if emails_inconsistent_accounts:
+            raise Exception(
+                f"There are members in a course iteration OU with an inconsistent course iteration tag.\
+                      Inconsistent names are {emails_inconsistent_accounts}"
+            )
 
     def check_double_iteration_names(self, AWSdata: AWSTree) -> None:
         """Check if there are multiple OU's with the same name in AWS."""
         names = [iteration.name for iteration in AWSdata.iterations]
-        doubles = []
+        duplicates = [iteration_name for iteration_name in set(names) if names.count(iteration_name) > 1]
 
-        for name in names:
-            if names.count(name) != 1 and name not in doubles:
-                doubles.append(name)
-
-        if doubles != []:
-            self.logger.error("There are multiple course iteration OUs with the same name.")
-            self.logger.debug(f"{doubles}")
-            raise Exception("There are multiple course iteration OUs with the same name.")
+        if duplicates:
+            raise Exception(
+                f"There are multiple course iteration OUs with the same name. Duplicates are: {duplicates}"
+            )

--- a/website/projects/awssync_checks.py
+++ b/website/projects/awssync_checks.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+
+from projects.awssync_structs import AWSTree
+
+
+class Checks:
+    """Class for pipline checks."""
+
+    def __init__(self) -> None:
+        """Initialize Checks class."""
+        self.logger = logging.getLogger("django.aws")
+        self.logger.setLevel(logging.DEBUG)
+
+    def check_members_in_correct_iteration(self, AWSdata: AWSTree) -> None:
+        """Check if the data from the member tag matches the semester OU it is in."""
+        incorrect_emails = []
+        for iteration in AWSdata.iterations:
+            for member in iteration.members:
+                if member.project_semester != iteration.name:
+                    incorrect_emails.append(member.project_email)
+
+        if incorrect_emails != []:
+            self.logger.error("There are members in a course iteration OU with an inconsistent course iteration tag.")
+            self.logger.debug(f"{incorrect_emails}")
+            raise Exception("There are members in a course iteration OU with an inconsistent course iteration tag.")
+
+    def check_double_iteration_names(self, AWSdata: AWSTree) -> None:
+        """Check if there are multiple OU's with the same name in AWS."""
+        names = [iteration.name for iteration in AWSdata.iterations]
+        doubles = []
+
+        for name in names:
+            if names.count(name) != 1 and name not in doubles:
+                doubles.append(name)
+
+        if doubles != []:
+            self.logger.error("There are multiple course iteration OUs with the same name.")
+            self.logger.debug(f"{doubles}")
+            raise Exception("There are multiple course iteration OUs with the same name.")

--- a/website/projects/tests/test_awssync.py
+++ b/website/projects/tests/test_awssync.py
@@ -618,9 +618,7 @@ class AWSSyncTest(TestCase):
         self.sync.extract_aws_setup = MagicMock(return_value=aws_tree)
         self.sync.get_emails_with_teamids = MagicMock(return_value=gip_teams)
         with patch.object(Semester.objects, "get_or_create_current_semester", return_value="Spring 2023"):
-            success = self.sync.pipeline()
-
-        self.assertFalse(success)
+            self.assertRaises(Exception, self.sync.pipeline)
 
     def test_pipeline__edge_case_double_iteration_names(self):
         moto_client = boto3.client("organizations")
@@ -643,9 +641,7 @@ class AWSSyncTest(TestCase):
         self.sync.extract_aws_setup = MagicMock(return_value=aws_tree)
         self.sync.get_emails_with_teamids = MagicMock(return_value=gip_teams)
         with patch.object(Semester.objects, "get_or_create_current_semester", return_value="Spring 2023"):
-            success = self.sync.pipeline()
-
-        self.assertFalse(success)
+            self.assertRaises(Exception, self.sync.pipeline)
 
     def test_pipeline__failed_creating_iteration_ou(self):
         moto_client = boto3.client("organizations")

--- a/website/projects/tests/test_awssync_checks.py
+++ b/website/projects/tests/test_awssync_checks.py
@@ -1,0 +1,93 @@
+"""Tests for awssync/checks.py."""
+
+from django.test import TestCase
+
+from projects.awssync_checks import Checks
+from projects.awssync_structs import AWSTree, Iteration, SyncData
+
+
+class ChecksTest(TestCase):
+    def setUp(self):
+        self.checks = Checks()
+        self.aws_tree1 = AWSTree(
+            "AWS Tree",
+            "12345",
+            [
+                Iteration(
+                    "Fall 2020",
+                    "54321",
+                    [
+                        SyncData("email1@example.com", "project1", "Fall 2020"),
+                        SyncData("email2@example.com", "project2", "Fall 2020"),
+                    ],
+                ),
+                Iteration(
+                    "Spring 2021",
+                    "98765",
+                    [
+                        SyncData("email3@example.com", "project3", "Spring 2021"),
+                        SyncData("email4@example.com", "project4", "Spring 2021"),
+                    ],
+                ),
+            ],
+        )
+
+        self.aws_tree2 = AWSTree(
+            "AWS Tree",
+            "12345",
+            [
+                Iteration(
+                    "Fall 2020",
+                    "54321",
+                    [
+                        SyncData("email1@example.com", "project1", "Fall 2020"),
+                        SyncData("email2@example.com", "project2", "Fall 2020"),
+                    ],
+                ),
+                Iteration(
+                    "Spring 2021",
+                    "98765",
+                    [
+                        SyncData("email3@example.com", "project3", "Fall 2021"),
+                        SyncData("email4@example.com", "project4", "Spring 2021"),
+                    ],
+                ),
+            ],
+        )
+
+        self.aws_tree3 = AWSTree(
+            "AWS Tree",
+            "12345",
+            [
+                Iteration(
+                    "Fall 2020",
+                    "54321",
+                    [
+                        SyncData("email1@example.com", "project1", "Fall 2020"),
+                        SyncData("email2@example.com", "project2", "Fall 2020"),
+                    ],
+                ),
+                Iteration(
+                    "Fall 2020",
+                    "98765",
+                    [
+                        SyncData("email3@example.com", "project3", "Fall 2021"),
+                        SyncData("email4@example.com", "project4", "Spring 2021"),
+                    ],
+                ),
+            ],
+        )
+
+    def test_check_members_in_correct_iteration(self):
+        # Test when correct
+        self.assertIsNone(self.checks.check_members_in_correct_iteration(self.aws_tree1))
+
+        # Test when incorrect
+        self.assertRaises(Exception, self.checks.check_members_in_correct_iteration, self.aws_tree2)
+
+    def test_check_double_iteration_names(self):
+        # Test when correct
+        self.assertIsNone(self.checks.check_double_iteration_names(self.aws_tree1))
+
+        # Test when double
+        self.assertRaises(Exception, self.checks.check_double_iteration_names, self.aws_tree3)

--- a/website/projects/tests/test_awssync_structs.py
+++ b/website/projects/tests/test_awssync_structs.py
@@ -182,24 +182,6 @@ class AWSTreeChecksTest(TestCase):
             val1, val2 = self.sync.check_current_ou_exists(self.aws_tree1)
             self.assertEqual((val1, val2), (True, "98765"))
 
-    def test_check_members_in_correct_iteration(self):
-        # Test when correct
-        val1, val2 = self.sync.check_members_in_correct_iteration(self.aws_tree1)
-        self.assertEqual((val1, val2), (True, None))
-
-        # Test when incorrect
-        val1, val2 = self.sync.check_members_in_correct_iteration(self.aws_tree2)
-        self.assertEqual((val1, val2), (False, ["email3@example.com"]))
-
-    def test_check_double_iteration_names(self):
-        # Test when correct
-        val1, val2 = self.sync.check_double_iteration_names(self.aws_tree1)
-        self.assertEqual((val1, val2), (False, None))
-
-        # Test when double
-        val1, val2 = self.sync.check_double_iteration_names(self.aws_tree3)
-        self.assertEqual((val1, val2), (True, ["Fall 2020"]))
-
     def test_AWSTree_equals(self):
         self.assertEqual(self.aws_tree1, self.aws_tree1)
         self.assertNotEqual(self.aws_tree1, self.aws_tree2)


### PR DESCRIPTION
<!-- Specify the issue this pull request closes, if any. -->
Closes #41

### One-sentence description
Refactored `check_members_in_correct_iteration` and `check_double_iteration_names` to their own file, as well as their tests.

### Description
I have not created folders for the AWS files and AWS test files. I would like to, but as we have not decided on a naming scheme we should do that at a later time to avoid merging headaches with other branches that might have different names.

I have quickly changed the pipeline function and its tests to keep the tests from failing. This will be changed later anyways, but I couldn't cope with the red cross on my screen when linting and testing. I also think the removal of checks that are not needed anymore should be handled by the person who refactors the pipeline functionality, as everything will break if I start removing checks without changing the pipeline (which I was not supposed to do, as discussed last meeting).
