### PR TITLE
Refactor creating course OU and attaching policy

### DIFF
--- a/website/projects/aws/awssync_refactored.py
+++ b/website/projects/aws/awssync_refactored.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-
 from botocore.exceptions import ClientError
 
 from courses.models import Semester
@@ -16,9 +14,6 @@ class AWSSyncRefactored:
     def __init__(self):
         """Create an AWSSync instance."""
         self.api_talker = AWSAPITalker()
-
-        self.logger = logging.getLogger("django.aws")
-        self.logger.setLevel(logging.DEBUG)
 
     def create_course_ou(self, tree: AWSTree) -> str:
         """Create organizational unit under root with name of current semester."""

--- a/website/projects/aws/awssync_refactored.py
+++ b/website/projects/aws/awssync_refactored.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import logging
 
+from botocore.exceptions import ClientError
+
+from courses.models import Semester
+
 from projects.aws.awsapitalker import AWSAPITalker
+from projects.aws.awssync_structs import AWSTree
 
 
 class AWSSyncRefactored:
@@ -14,3 +19,23 @@ class AWSSyncRefactored:
 
         self.logger = logging.getLogger("django.aws")
         self.logger.setLevel(logging.DEBUG)
+
+    def create_course_ou(self, tree: AWSTree) -> str:
+        """Create organizational unit under root with name of current semester."""
+        root_id = tree.ou_id
+        course_ou_name = str(Semester.objects.get_or_create_current_semester())
+        course_ou_id = next((ou.ou_id for ou in tree.iterations if ou.name == course_ou_name), None)
+
+        if not course_ou_id:
+            course_ou = self.api_talker.create_organizational_unit(root_id, course_ou_name)
+            course_ou_id = course_ou["OrganizationalUnit"]["Id"]
+
+        return course_ou_id
+
+    def attach_policy(self, target_id: str, policy_id: str) -> None:
+        """Attach policy to target resource."""
+        try:
+            self.api_talker.attach_policy(target_id, policy_id)
+        except ClientError as error:
+            if error.response["Error"]["Code"] != "DuplicatePolicyAttachmentException":
+                raise

--- a/website/projects/aws/awssync_refactored.py
+++ b/website/projects/aws/awssync_refactored.py
@@ -15,7 +15,7 @@ class AWSSyncRefactored:
         """Create an AWSSync instance."""
         self.api_talker = AWSAPITalker()
 
-    def create_course_ou(self, tree: AWSTree) -> str:
+    def get_or_create_course_ou(self, tree: AWSTree) -> str:
         """Create organizational unit under root with name of current semester."""
         root_id = tree.ou_id
         course_ou_name = str(Semester.objects.get_or_create_current_semester())

--- a/website/projects/aws/awssync_refactored.py
+++ b/website/projects/aws/awssync_refactored.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import logging
+
+from projects.aws.awsapitalker import AWSAPITalker
+
+
+class AWSSyncRefactored:
+    """Synchronise with Amazon Web Services."""
+
+    def __init__(self):
+        """Create an AWSSync instance."""
+        self.api_talker = AWSAPITalker()
+
+        self.logger = logging.getLogger("django.aws")
+        self.logger.setLevel(logging.DEBUG)

--- a/website/projects/tests/tests_aws/test_awssync_refactored.py
+++ b/website/projects/tests/tests_aws/test_awssync_refactored.py
@@ -1,0 +1,9 @@
+"""Tests for awssync_refactored.py."""
+from django.test import TestCase
+
+from projects.aws.awssync_refactored import AWSSyncRefactored
+
+
+class AWSSyncRefactoredTest(TestCase):
+    def setUp(self):
+        self.sync = AWSSyncRefactored()

--- a/website/projects/tests/tests_aws/test_awssync_refactored.py
+++ b/website/projects/tests/tests_aws/test_awssync_refactored.py
@@ -1,9 +1,80 @@
 """Tests for awssync_refactored.py."""
+import json
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+
 from django.test import TestCase
 
+from moto import mock_organizations
+
+from courses.models import Semester
+
 from projects.aws.awssync_refactored import AWSSyncRefactored
+from projects.aws.awssync_structs import AWSTree, Iteration, SyncData
 
 
+@mock_organizations
 class AWSSyncRefactoredTest(TestCase):
     def setUp(self):
         self.sync = AWSSyncRefactored()
+
+    def test_create_course_ou__not_exists(self):
+        self.sync.api_talker.create_organization(feature_set="ALL")
+        root_id = self.sync.api_talker.list_roots()[0]["Id"]
+        tree = AWSTree("root", root_id, [])
+
+        with patch.object(Semester.objects, "get_or_create_current_semester", return_value="Spring 2023"):
+            course_ou_id = self.sync.create_course_ou(tree)
+        ous = self.sync.api_talker.list_organizational_units_for_parent(root_id)
+        ou_ids = [ou["Id"] for ou in ous]
+
+        self.assertIn(course_ou_id, ou_ids)
+
+    def test_create_course_ou__exists(self):
+        tree = AWSTree(
+            "root",
+            "r-123",
+            [
+                Iteration("Spring 2023", "ou-456", [SyncData("alice@giphouse.nl", "alices-project", "Spring 2023")]),
+                Iteration("Fall 2023", "ou-789", [SyncData("bob@giphouse.nl", "bobs-project", "Fall 2023")]),
+            ],
+        )
+
+        with patch.object(Semester.objects, "get_or_create_current_semester", return_value="Spring 2023"):
+            course_ou_id = self.sync.create_course_ou(tree)
+        self.assertEquals("ou-456", course_ou_id)
+
+    def test_attach_policy__not_attached(self):
+        self.sync.api_talker.create_organization(feature_set="ALL")
+        root_id = self.sync.api_talker.list_roots()[0]["Id"]
+
+        new_policy_content = json.dumps(
+            {"Version": "2012-10-17", "Statement": [{"Effect": "Deny", "Action": "*", "Resource": "*"}]}
+        )
+        new_policy_id = self.sync.api_talker.org_client.create_policy(
+            Content=new_policy_content, Description="Deny all access.", Name="DenyAll", Type="SERVICE_CONTROL_POLICY"
+        )["Policy"]["PolicySummary"]["Id"]
+
+        self.sync.attach_policy(root_id, new_policy_id)
+        attached_policies = self.sync.api_talker.org_client.list_policies_for_target(
+            TargetId=root_id, Filter="SERVICE_CONTROL_POLICY"
+        )["Policies"]
+        attached_policy_ids = [policy["Id"] for policy in attached_policies]
+
+        self.assertIn(new_policy_id, attached_policy_ids)
+
+    def test_attach_policy__caught_exception(self):
+        # Error code "DuplicatePolicyAttachmentException" can not be simulated by moto, so it is mocked.
+        attach_policy_hard_side_effect = ClientError(
+            {"Error": {"Code": "DuplicatePolicyAttachmentException"}}, "attach_policy"
+        )
+        with patch.object(
+            self.sync.api_talker.org_client, "attach_policy", side_effect=attach_policy_hard_side_effect
+        ):
+            return_value = self.sync.attach_policy("r-123", "p-123")
+
+        self.assertIsNone(return_value)
+
+    def test_attach_policy__reraised_exception(self):
+        self.assertRaises(ClientError, self.sync.attach_policy, "r-123", "p-123")

--- a/website/projects/tests/tests_aws/test_awssync_refactored.py
+++ b/website/projects/tests/tests_aws/test_awssync_refactored.py
@@ -48,7 +48,7 @@ class AWSSyncRefactoredTest(TestCase):
 
         with patch.object(Semester.objects, "get_or_create_current_semester", return_value="Spring 2023"):
             course_ou_id = self.sync.create_course_ou(tree)
-        self.assertEquals("ou-456", course_ou_id)
+        self.assertEqual("ou-456", course_ou_id)
 
     def test_attach_policy__not_attached(self):
         self.sync.api_talker.create_organization(feature_set="ALL")

--- a/website/projects/tests/tests_aws/test_awssync_refactored.py
+++ b/website/projects/tests/tests_aws/test_awssync_refactored.py
@@ -19,14 +19,14 @@ class AWSSyncRefactoredTest(TestCase):
     def setUp(self):
         self.sync = AWSSyncRefactored()
 
-    def test_create_course_ou__new(self):
+    def test_get_or_create_course_ou__new(self):
         self.sync.api_talker.create_organization(feature_set="ALL")
         root_id = self.sync.api_talker.list_roots()[0]["Id"]
         tree = AWSTree("root", root_id, [])
         current_semester_name = "Spring 2023"
 
         with patch.object(Semester.objects, "get_or_create_current_semester", return_value=current_semester_name):
-            course_ou_id = self.sync.create_course_ou(tree)
+            course_ou_id = self.sync.get_or_create_course_ou(tree)
 
         course_ou_exists = any(
             ou["Id"] == course_ou_id and ou["Name"] == current_semester_name
@@ -35,7 +35,7 @@ class AWSSyncRefactoredTest(TestCase):
 
         self.assertTrue(course_ou_exists)
 
-    def test_create_course_ou__already_exists(self):
+    def test_get_or_create_course_ou__already_exists(self):
         tree = AWSTree(
             "root",
             "r-123",
@@ -46,7 +46,7 @@ class AWSSyncRefactoredTest(TestCase):
         )
 
         with patch.object(Semester.objects, "get_or_create_current_semester", return_value="Spring 2023"):
-            course_ou_id = self.sync.create_course_ou(tree)
+            course_ou_id = self.sync.get_or_create_course_ou(tree)
         self.assertEqual("ou-456", course_ou_id)
 
     def test_attach_policy__not_attached(self):

--- a/website/projects/tests/tests_aws/test_awssync_refactored.py
+++ b/website/projects/tests/tests_aws/test_awssync_refactored.py
@@ -19,7 +19,7 @@ class AWSSyncRefactoredTest(TestCase):
     def setUp(self):
         self.sync = AWSSyncRefactored()
 
-    def test_create_course_ou__not_exists(self):
+    def test_create_course_ou__new(self):
         self.sync.api_talker.create_organization(feature_set="ALL")
 
         root_id = self.sync.api_talker.list_roots()[0]["Id"]
@@ -36,7 +36,7 @@ class AWSSyncRefactoredTest(TestCase):
         self.assertIn(course_ou_id, ou_ids)
         self.assertIn(current_semester_name, ou_names)
 
-    def test_create_course_ou__exists(self):
+    def test_create_course_ou__already_exists(self):
         tree = AWSTree(
             "root",
             "r-123",

--- a/website/projects/tests/tests_aws/test_awssync_refactored.py
+++ b/website/projects/tests/tests_aws/test_awssync_refactored.py
@@ -21,7 +21,6 @@ class AWSSyncRefactoredTest(TestCase):
 
     def test_create_course_ou__new(self):
         self.sync.api_talker.create_organization(feature_set="ALL")
-
         root_id = self.sync.api_talker.list_roots()[0]["Id"]
         tree = AWSTree("root", root_id, [])
         current_semester_name = "Spring 2023"
@@ -29,12 +28,12 @@ class AWSSyncRefactoredTest(TestCase):
         with patch.object(Semester.objects, "get_or_create_current_semester", return_value=current_semester_name):
             course_ou_id = self.sync.create_course_ou(tree)
 
-        ous = self.sync.api_talker.list_organizational_units_for_parent(root_id)
-        ou_ids = [ou["Id"] for ou in ous]
-        ou_names = [ou["Name"] for ou in ous]
+        course_ou_exists = any(
+            ou["Id"] == course_ou_id and ou["Name"] == current_semester_name
+            for ou in self.sync.api_talker.list_organizational_units_for_parent(root_id)
+        )
 
-        self.assertIn(course_ou_id, ou_ids)
-        self.assertIn(current_semester_name, ou_names)
+        self.assertTrue(course_ou_exists)
 
     def test_create_course_ou__already_exists(self):
         tree = AWSTree(

--- a/website/projects/tests/tests_aws/test_awssync_refactored.py
+++ b/website/projects/tests/tests_aws/test_awssync_refactored.py
@@ -21,15 +21,20 @@ class AWSSyncRefactoredTest(TestCase):
 
     def test_create_course_ou__not_exists(self):
         self.sync.api_talker.create_organization(feature_set="ALL")
+
         root_id = self.sync.api_talker.list_roots()[0]["Id"]
         tree = AWSTree("root", root_id, [])
+        current_semester_name = "Spring 2023"
 
-        with patch.object(Semester.objects, "get_or_create_current_semester", return_value="Spring 2023"):
+        with patch.object(Semester.objects, "get_or_create_current_semester", return_value=current_semester_name):
             course_ou_id = self.sync.create_course_ou(tree)
+
         ous = self.sync.api_talker.list_organizational_units_for_parent(root_id)
         ou_ids = [ou["Id"] for ou in ous]
+        ou_names = [ou["Name"] for ou in ous]
 
         self.assertIn(course_ou_id, ou_ids)
+        self.assertIn(current_semester_name, ou_names)
 
     def test_create_course_ou__exists(self):
         tree = AWSTree(


### PR DESCRIPTION
<!-- Specify the issue this pull request closes, if any. -->
Closes #51 

### One-sentence description
<!-- Describe in one sentence what this pull request accomplishes. -->
Increased code quality for (1) creating a course organizational unit and (2) attaching a policy to a target resource.

### Description
<!-- Describe in detail why this pull request is needed. -->
- Created a new class `AWSSyncRefactored` in a separate file, as well as for its units tests. Alternative would have been to process the changes in the current `AWSSync` class. However, this would have been a major headache (think about return values changing, pipeline requiring changes, causing unit tests to break, etc.) and require significantly more time. Disadvantage of working in a new class is that the changes made with respect to what we previously had, is less obvious when looking at commit differences. Advantage is that we rebuild everything bottom-up, can ensure we only add high quality code, and we have to think less about what effects the made changes have on rest of code.
- The function for creating a policy has been removed since only attaching a pre-made SCP policy is needed, as discussed during sprint 2 review with client. We should look where to place its policy ID in sprint 4 (probably as environment variable).
- As for refactoring, I managed to greatly simplify and reduce the number of lines of code, increasing code readability and thus code quality. It was previously really a mess; simple things were somehow made artificially complex.